### PR TITLE
Add semi-analytic image generation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,16 @@ build/*
 gsl_ellip.c
 toms_ellip_binding.py
 toms5777*
+
+# macOS
+.DS_Store
+
+# local experimental scripts / patches
+/generate_semianalytic_image.py
+kgeo/equatorial_images_fluid_bfield_patch.py
+scripts/first_image.py
+scripts/samik_model_BandU.py
+
+# generated images / fits files
+*.png
+*.fits

--- a/kgeo/bfields.py
+++ b/kgeo/bfields.py
@@ -41,7 +41,8 @@ class Bfield:
 
         if self.fieldtype in ['rad', 'vert', 'tor', 'simple', 'simple_rm1',
                               'monopoleA', 'bz_monopole', 'bz_guess',
-                              'bz_para', 'power', 'get_power', 'fromfile', 'fromdict']:
+                              'bz_para', 'power', 'gen_power', 'fromfile', 'fromdict',
+                              'fluid_file']:
             self.fieldframe = 'lab'
         elif self.fieldtype in ['const_comoving']:
             self.fieldframe = 'comoving'
@@ -82,6 +83,18 @@ class Bfield:
             self.cached_data = load_cache_from_file(self.filename)
         elif self.fieldtype == 'fromdict':
             self.cached_data = self.kwargs.get('data', None)
+        # fluid-frame b^mu tabulated in a file: columns r, b^r, b^phi (BL coords, equatorial)
+        elif self.fieldtype == 'fluid_file':
+            self.filename = self.kwargs.get('file', None)
+            self.velocity = self.kwargs.get('velocity', None)
+            if self.filename is None:
+                raise Exception("fluid_file Bfield needs a 'file' keyword argument!")
+            if self.velocity is None:
+                raise Exception("fluid_file Bfield needs a 'velocity' keyword argument "
+                                "(the same Velocity object used in the image calculation)!")
+            self.cached_data = load_fluid_bfield_file(self.filename)
+            # default False: linear order in H/r (midplane metric)
+            self.cached_data['_surface_metric'] = bool(self.kwargs.get('surface_metric', False))
         # added model
         elif self.fieldtype == 'gen_power':
             self.n_I = self.kwargs.get('n_I', 0)
@@ -131,6 +144,9 @@ class Bfield:
             b_components = (B1, B2, B3)
         elif self.fieldtype in ['fromfile', 'fromdict']:
             B1, B2, B3 = Bfield_from_cache(a, r, self.cached_data)
+            b_components = B1, B2, B3
+        elif self.fieldtype == 'fluid_file':
+            B1, B2, B3 = Bfield_from_fluid_file(a, r, self.cached_data, self.velocity, th=th)
             b_components = B1, B2, B3
         else:
             raise Exception(f"fieldtype {self.fieldtype} not recognized in Bfield.bfield_lab!")
@@ -819,3 +835,139 @@ def Bfield_from_cache(a, r, rb123_cache):
     Bph = np.interp(r, rb123_cache['radii'], rb123_cache['Bph'])
 
     return (Br, Bth, Bph)
+
+
+def load_fluid_bfield_file(filename):
+    """
+    Load fluid-frame magnetic field components tabulated vs radius from a
+    plain text file (whitespace- or comma-separated, no header needed).
+
+    Expected columns, either:
+        4 columns:  r, b^0, b^r, b^phi
+        3 columns:  r, b^r, b^phi      (b^0 derived from u_mu b^mu = 0)
+    (Boyer-Lindquist coordinates, equatorial plane, fluid-frame four-vector b^mu,
+     with b^theta = 0)
+    """
+    try:
+        data = np.loadtxt(filename)
+    except ValueError:
+        data = np.loadtxt(filename, delimiter=',')
+
+    if data.ndim != 2 or data.shape[1] < 3:
+        raise Exception(f"fluid bfield file {filename} must have 3 or 4 columns!")
+
+    radii = data[:, 0]
+    if np.any(np.diff(radii) <= 0):
+        idx = np.argsort(radii)
+        data = data[idx]
+        radii = data[:, 0]
+
+    out = dict(radii=radii)
+    if data.shape[1] >= 4:
+        out.update(b0=data[:, 1], br=data[:, 2], bph=data[:, 3])
+    else:
+        out.update(b0=None, br=data[:, 1], bph=data[:, 2])
+    # optional extra columns of the combined model file
+    if data.shape[1] >= 10:
+        out['hor'] = data[:, 9]            # scale height H/r -> theta = arccos(H/r)
+    if data.shape[1] >= 11:
+        out['beta'] = data[:, 10]          # plasma beta (loaded, available)
+    return out
+
+
+def Bfield_from_fluid_file(a, r, rbrbph_cache, velocity, th=np.pi/2.):
+    """
+    Convert tabulated fluid-frame b^mu = (b^0, b^r, 0, b^phi) to lab-frame
+    'primitive' field B^i = *F^{i0}, which is what the kgeo imaging pipeline expects.
+
+    Uses the ideal-MHD degeneracy inversion:
+        b^0 = -(b^r u_r + b^phi u_phi) / u_0     [from u_mu b^mu = 0]
+        B^i = u^0 b^i - b^0 u^i
+
+    'velocity' must be the same kgeo Velocity object used in the image calculation,
+    so that the forward transform in equatorial_images.py exactly recovers
+    the tabulated fluid-frame components.
+
+    Note: by convention one file corresponds to a single spin; outside the
+    tabulated radius range the components are set to zero.
+    """
+    if not isinstance(r, np.ndarray):
+        r = np.array([r]).flatten()
+
+    radii = rbrbph_cache['radii']
+
+    # interpolate fluid-frame components; zero outside tabulated range
+    br = np.interp(r, radii, rbrbph_cache['br'], left=0., right=0.)
+    bph = np.interp(r, radii, rbrbph_cache['bph'], left=0., right=0.)
+
+    # LINEAR ORDER IN H/r: the Kerr metric depends on theta only through
+    # cos^2(theta) = (H/r)^2 and sin^2(theta) = 1-(H/r)^2, so to first order in
+    # H/r the surface metric equals the midplane metric. Metric operations are
+    # therefore evaluated at th (default pi/2); the scale height enters the
+    # calculation only through the pathlength, where it appears linearly.
+    # (Set surface_metric=True on the Bfield to restore the O((H/r)^2) metric.)
+    if rbrbph_cache.get('hor', None) is not None and rbrbph_cache.get('_surface_metric', False):
+        hor = np.interp(r, radii, rbrbph_cache['hor'], left=0., right=0.)
+        th = np.arccos(np.clip(hor, 0., 1.))
+
+    # BL metric components at theta
+    a2 = a**2
+    r2 = r**2
+    cth2 = np.cos(th)**2
+    sth2 = np.sin(th)**2
+    Sigma = r2 + a2*cth2
+    g00 = -(1.0 - 2.0*r/Sigma)
+    g11 = Sigma/(r2 - 2.0*r + a2)
+    g33 = (r2 + a2 + 2.0*r*a2*sth2/Sigma)*sth2
+    g03 = -2.0*r*a*sth2/Sigma
+
+    # contravariant four-velocity from the velocity model
+    (u0, u1, u2, u3) = velocity.u_lab(a, r, th=th)
+
+    # lower indices
+    u0_l = g00*u0 + g03*u3
+    u1_l = g11*u1
+    u3_l = g33*u3 + g03*u0
+
+    # b^0: ALWAYS derived from orthogonality u_mu b^mu = 0 with the interpolated
+    # u^mu, so field and flow are exactly consistent at every requested radius
+    # (b^theta = 0 in the equatorial plane).
+    b0 = -(br*u1_l + bph*u3_l)/u0_l
+
+    # one-time validation: if the file tabulates b^0, compare it against
+    # orthogonality ON THE TABULATED GRID (interpolation-free), and warn if
+    # the velocity model does not match the model that produced the field.
+    if rbrbph_cache.get('b0', None) is not None and not rbrbph_cache.get('_b0checked', False):
+        rr = radii
+        thg = th
+        if rbrbph_cache.get('hor', None) is not None and rbrbph_cache.get('_surface_metric', False):
+            thg = np.arccos(np.clip(rbrbph_cache['hor'], 0., 1.))
+        a2g = a**2; r2g = rr**2
+        cth2g = np.cos(thg)**2; sth2g = np.sin(thg)**2
+        Sigmag = r2g + a2g*cth2g
+        Deltag = r2g - 2.0*rr + a2g
+        g00g = -(1.0 - 2.0*rr/Sigmag)
+        g11g = Sigmag/Deltag
+        g33g = (r2g + a2g + 2.0*rr*a2g*sth2g/Sigmag)*sth2g
+        g03g = -2.0*rr*a*sth2g/Sigmag
+        (v0, v1, v2, v3) = velocity.u_lab(a, rr, th=thg)
+        v0_l = g00g*v0 + g03g*v3
+        v1_l = g11g*v1
+        v3_l = g33g*v3 + g03g*v0
+        b0g = -(rbrbph_cache['br']*v1_l + rbrbph_cache['bph']*v3_l)/v0_l
+        maskg = np.abs(rbrbph_cache['b0']) > 0
+        if np.any(maskg):
+            relerr = np.max(np.abs(b0g[maskg] - rbrbph_cache['b0'][maskg])
+                            / np.abs(rbrbph_cache['b0'][maskg]))
+            if relerr > 1e-2:
+                print(f"WARNING: tabulated b^0 disagrees with u_mu b^mu = 0 on the "
+                      f"data grid (max rel err {relerr:.2e})! "
+                      f"Check that the Velocity object matches the u^mu of your model.")
+        rbrbph_cache['_b0checked'] = True
+
+    # invert the degeneracy relations: B^i = u^0 b^i - b^0 u^i
+    B1 = u0*br - b0*u1
+    B2 = np.zeros_like(B1)
+    B3 = u0*bph - b0*u3
+
+    return (B1, B2, B3)

--- a/kgeo/emissivities.py
+++ b/kgeo/emissivities.py
@@ -50,6 +50,19 @@ class Emissivity:
             self.alpha_B = float(self.kwargs.get('alpha_B', 1.5))
             self.bfield_model = bool(self.kwargs.get('bfield_model', False))
 
+        # thermal synchrotron with tabulated radial profiles n_e(r), T_e(r)
+        elif self.emistype=='thermal_file':
+            self.filename = self.kwargs.get('file', None)
+            if self.filename is None:
+                raise Exception("thermal_file Emissivity needs a 'file' keyword argument!")
+            # temperature column units: 'K' (Kelvin, default) or 'dimensionless' (Theta_e = kT/me c^2)
+            self.temp_kind = self.kwargs.get('temp_kind', 'K')
+            # multiplicative factor applied to the tabulated temperature
+            # (e.g. Te_scale=0.1 for an electron temperature 10x below tabulated T)
+            self.Te_scale = float(self.kwargs.get('Te_scale', 1.0))
+            self.cached_data = load_thermal_profile_file(self.filename)
+            self.cached_data['_surface_metric'] = bool(self.kwargs.get('surface_metric', False))
+
         elif self.emistype=='bpl':
             self.p1 = self.kwargs.get('p1', P1E_230)
             self.p2 = self.kwargs.get('p2', P2E_230)
@@ -90,6 +103,50 @@ class Emissivity:
 
             j = j_nu_thermal(ne, B, Te, nu_em, sinthetab)
 
+        elif self.emistype=='thermal_file':
+            nu_em = np.asarray(nu_obs) / np.asarray(g)     # emitted frequency in fluid frame
+            cache = self.cached_data
+            ne = np.interp(r, cache['radii'], cache['ne'], left=0., right=0.)  # cm^-3
+            Te = np.interp(r, cache['radii'], cache['Te'], left=0., right=0.)
+            Te = Te * self.Te_scale
+            if self.temp_kind == 'dimensionless':
+                Te = Te * (me*c*c/kB)                      # Theta_e -> Kelvin
+            # B in Gauss: computed directly from the tabulated fluid-frame b^mu,
+            # |b| = sqrt(b_mu b^mu), evaluated with the BL metric ON THE DATA GRID
+            # (interpolation-free), then interpolated in radius. Falls back to the
+            # pipeline-provided Bmag if the file has no b^mu columns.
+            if cache.get('b0', None) is not None:
+                if cache.get('_Bmag_grid', None) is None:
+                    rr = cache['radii']
+                    # linear order in H/r: midplane metric (theta corrections O((H/r)^2))
+                    if cache.get('hor', None) is not None and cache.get('_surface_metric', False):
+                        cthg = np.clip(cache['hor'], 0., 1.); sth2g = 1. - cthg**2
+                    else:
+                        cthg = np.zeros_like(rr); sth2g = np.ones_like(rr)
+                    a2g, r2g = a**2, rr**2
+                    Deltag = r2g - 2.*rr + a2g
+                    Sigmag = r2g + a2g*cthg**2
+                    g00g = -(1. - 2.*rr/Sigmag)
+                    g11g = Sigmag/Deltag
+                    g33g = (r2g + a2g + 2.*rr*a2g*sth2g/Sigmag)*sth2g
+                    g03g = -2.*rr*a*sth2g/Sigmag
+                    bb0, bbr, bbp = cache['b0'], cache['br'], cache['bph']
+                    b_t  = g00g*bb0 + g03g*bbp
+                    b_r  = g11g*bbr
+                    b_ph = g33g*bbp + g03g*bb0
+                    bsqg = b_t*bb0 + b_r*bbr + b_ph*bbp     # Gauss^2, spacelike > 0
+                    cache['_Bmag_grid'] = np.sqrt(np.clip(bsqg, 0., None))
+                B = np.interp(r, cache['radii'], cache['_Bmag_grid'], left=0., right=0.)
+            else:
+                B = np.asarray(Bmag, dtype=float)
+            # guard: no emission where tabulated values are nonphysical (e.g. Te<=0)
+            good = (ne > 0) & (Te > 0) & np.isfinite(B) & (B > 0)
+            j = np.zeros_like(np.asarray(r, dtype=float))
+            if np.any(good):
+                j[good] = j_nu_thermal(ne[good], B[good], Te[good],
+                                       np.broadcast_to(nu_em, j.shape)[good],
+                                       np.broadcast_to(sinthetab, j.shape)[good])
+
         ## Phenomenological models
         elif self.emistype=='constant':
             j = np.ones(r.shape)
@@ -104,7 +161,7 @@ class Emissivity:
             raise Exception(f"emistype {self.emistype} not recognized in Emissivity.emis!")
 
         # add spectral behavior for non-physical emissivities
-        if self.emistype != 'thermal':
+        if self.emistype not in ('thermal', 'thermal_file'):
             if g is not None:
                 j *=  (g**specind)
             if sinthetab is not None:
@@ -150,3 +207,46 @@ def j_nu_thermal(ne, B, Te, nu, sin_thetaB):
     nu_c = nu_c_fcn(B, Theta_e, sin_thetaB)
     x = nu/np.maximum(nu_c, 1e-40) # strictly valid only in nu > nu_c limit
     return (ne * e**2 * nu)/(2 * np.sqrt(3) * c * (Theta_e**2)) * II_fit(x)
+
+
+def load_thermal_profile_file(filename):
+    """
+    Load tabulated radial plasma profiles for the thermal_file emissivity from
+    a plain text file (whitespace- or comma-separated, no header needed).
+
+    Expected columns, either:
+        3 columns:   r, n_e, T_e
+        9+ columns:  r, b^0, b^r, b^phi, u^0, u^r, u^phi, n_e, T_e
+                     (combined model file; columns 8-9 are used; the same file
+                     can be passed to Bfield/Velocity 'fluid_file')
+        r   : Boyer-Lindquist radius in units of M
+        n_e : electron number density in cm^-3 (e.g. rho/(mu_e*m_p))
+        T_e : electron temperature, in K by default
+              (pass temp_kind='dimensionless' if the column is Theta_e = kT/me c^2)
+    """
+    try:
+        data = np.loadtxt(filename)
+    except ValueError:
+        data = np.loadtxt(filename, delimiter=',')
+
+    if data.ndim != 2 or data.shape[1] < 3:
+        raise Exception(f"thermal profile file {filename} must have >=3 columns: r, n_e, T_e")
+
+    radii = data[:, 0]
+    if np.any(np.diff(radii) <= 0):
+        idx = np.argsort(radii)
+        data = data[idx]
+        radii = data[:, 0]
+
+    if data.shape[1] >= 9:
+        # combined model file: also keep b^mu to compute |b| = sqrt(b_mu b^mu)
+        # directly from the data (used for the synchrotron field strength)
+        out = dict(radii=radii, ne=data[:, 7], Te=data[:, 8],
+                   b0=data[:, 1], br=data[:, 2], bph=data[:, 3])
+        if data.shape[1] >= 10:
+            out['hor'] = data[:, 9]        # scale height H/r
+        if data.shape[1] >= 11:
+            out['beta'] = data[:, 10]      # plasma beta (loaded, available)
+        return out
+    else:
+        return dict(radii=radii, ne=data[:, 1], Te=data[:, 2])

--- a/kgeo/equatorial_images.py
+++ b/kgeo/equatorial_images.py
@@ -216,11 +216,6 @@ def Iobs(a, r_o, th_o, mbar, alpha, beta,
 
         sin_thb[~zeromask] = sinthb
 
-        if emissivity.emistype == 'thermal':
-            bsq0 = bfield.bsq(a, emissivity.Rb, velocity, th=th_s)
-            Bmag_vals = np.sqrt(bsq / bsq0) * emissivity.B0
-
-
         ###############################
         # get emissivity in local frame
         ###############################
@@ -442,9 +437,10 @@ def calc_polquantities(a, r, lam, eta, kr_sign, kth_sign,
     bsq = Bp_mag**2 # this is the comoving field strength, same as above
 
     norm_mag = np.sqrt(norm_x**2+norm_y**2+norm_z**2)
-    norm_x_unit = norm_x/norm_mag
-    norm_y_unit = norm_y/norm_mag
-    norm_z_unit = norm_z/norm_mag
+    norm_mag_safe = np.where(norm_mag > 0, norm_mag, 1.)
+    norm_x_unit = np.where(norm_mag > 0, norm_x/norm_mag_safe, 0.)
+    norm_y_unit = np.where(norm_mag > 0, norm_y/norm_mag_safe, 0.)
+    norm_z_unit = np.where(norm_mag > 0, norm_z/norm_mag_safe, 0.)
 
     # photon momentum/wavevector
     R = (r2 + a2 -a*lam)**2 - Delta*(eta + (lam-a)**2)
@@ -478,13 +474,15 @@ def calc_polquantities(a, r, lam, eta, kr_sign, kth_sign,
         pathfac = np.abs(r*np.sin(th))
     elif pathcor == 'Z':
         pathfac = np.abs(r*np.cos(th))
-    pathlength = np.abs(kp_t/kdotnorm)*pathfac #add correction to jet thickness
+    kdotnorm_safe = np.where(np.abs(kdotnorm) > 0, kdotnorm, 1.)
+    pathlength = np.where(np.abs(kdotnorm) > 0, np.abs(kp_t/kdotnorm_safe), 0.)*pathfac #add correction to jet thickness
 
     # local polarization vector and emission angle
     f_x = (kp_y*Bp_z - kp_z*Bp_y)/kp_mag
     f_y = (kp_z*Bp_x - kp_x*Bp_z)/kp_mag
     f_z = (kp_x*Bp_y - kp_y*Bp_x)/kp_mag
-    sinthb = np.sqrt(f_x**2 + f_y**2 + f_z**2)/Bp_mag
+    Bp_mag_safe = np.where(Bp_mag > 0, Bp_mag, 1.)
+    sinthb = np.where(Bp_mag > 0, np.sqrt(f_x**2 + f_y**2 + f_z**2)/Bp_mag_safe, 0.)
 
     # polarization four vector
     f0 = e0_x*f_x + e0_y*f_y + e0_z*f_z
@@ -517,7 +515,7 @@ def calc_pathlength_equatorial(a, r, lam, eta, kr_sign, kth_sign, u0, u1, u2, u3
 
     # get the y\propto\theta component of local photon momentum
     # TODO this assumes that u^2 == 0!
-    if (isinstance(u2,np.ndarray) and np.any(u2!=0)) or u2!=0:
+    if np.any(np.asarray(u2) != 0):
         raise Exception("calc_pathlength assumes that u2==0!")
     if (isinstance(th,np.ndarray) and np.any(th!=np.pi/2)) or th!=np.pi/2:
         raise Exception("calc_pathlength assumes that th==pi/2!")
@@ -529,7 +527,12 @@ def calc_pathlength_equatorial(a, r, lam, eta, kr_sign, kth_sign, u0, u1, u2, u3
     kyhat = -k2_l/r # valid only in equatorial plane
 
     # get path length
-    diskheight = diskangle*r
+    # diskangle may be a constant H/r (full opening angle) or a callable H/r(r)
+    # interpolated from a tabulated scale-height profile
+    if callable(diskangle):
+        diskheight = diskangle(r)*r
+    else:
+        diskheight = diskangle*r
     lp = diskheight * (kthat / kyhat)
 
     return lp

--- a/kgeo/velocities.py
+++ b/kgeo/velocities.py
@@ -17,7 +17,8 @@ BFIELD_DEFAULT = Bfield('bz_para')
 # used in testing
 _allowed_velocity_models = [
     'zamo', 'infall', 'kep', 'cunningham', 'subkep', 'cunningham_subkep',
-    'general', 'gelles', 'simfit', 'fromfile', 'fromdict', 'driftframe'
+    'general', 'gelles', 'simfit', 'fromfile', 'fromdict', 'driftframe',
+    'fluid_file'
 ]
 
 
@@ -55,6 +56,13 @@ class Velocity:
             self.cached_data = load_cache_from_file(self.filename)
         elif self.veltype == 'fromdict':
             self.cached_data = self.kwargs.get('data', None)
+        # four-velocity u^mu tabulated in a file: r, u^0, u^r, u^phi (BL, equatorial)
+        elif self.veltype == 'fluid_file':
+            self.filename = self.kwargs.get('file', None)
+            if self.filename is None:
+                raise Exception("fluid_file Velocity needs a 'file' keyword argument!")
+            self.cached_data = load_fluid_velocity_file(self.filename)
+            self.cached_data['_surface_metric'] = bool(self.kwargs.get('surface_metric', False))
         elif self.veltype == 'driftframe':
             self.bfield = self.kwargs.get('bfield', BFIELD_DEFAULT)
             self.nu_parallel = self.kwargs.get('nu_parallel', 0)
@@ -84,6 +92,8 @@ class Velocity:
             ucon = u_gelles(a, r, beta=self.gelles_beta, chi=self.gelles_chi)
         elif self.veltype == 'simfit':
             ucon = u_grmhd_fit(a, r, ell_isco=self.ell_isco, vr_isco=self.vr_isco, p1=self.p1, p2=self.p2, dd=self.dd)
+        elif self.veltype == 'fluid_file':
+            ucon = u_from_fluid_file(a, r, self.cached_data)
         elif self.veltype in ['fromfile', 'fromdict']:
             ucon = u_from_u123(a, r, self.cached_data)
         elif self.veltype=='driftframe':
@@ -976,3 +986,86 @@ def invmetric(r, a, theta, M):
 
     return np.swapaxes(ginvmunu, 0, -1) if hasattr(r, 'shape') else ginvmunu
 
+
+
+def load_fluid_velocity_file(filename):
+    """
+    Load contravariant four-velocity components u^0, u^r, u^phi tabulated vs
+    radius from a plain text file (whitespace- or comma-separated, no header).
+
+    Accepted column layouts:
+        4 columns:   r, u^0, u^r, u^phi
+        7+ columns:  r, b^0, b^r, b^phi, u^0, u^r, u^phi, [n_e, T_e, ...]
+                     (combined model file, columns 5-7 are used; the same file
+                     can be passed to Bfield('fluid_file') and
+                     Emissivity('thermal_file'))
+    (Boyer-Lindquist coordinates, equatorial plane, u^theta = 0,
+     geometrized units G=c=1 with r in units of M, u_mu u^mu = -1)
+    """
+    try:
+        data = np.loadtxt(filename)
+    except ValueError:
+        data = np.loadtxt(filename, delimiter=',')
+
+    if data.ndim != 2 or data.shape[1] < 4:
+        raise Exception(f"fluid velocity file {filename} must have >=4 columns!")
+
+    radii = data[:, 0]
+    if np.any(np.diff(radii) <= 0):
+        idx = np.argsort(radii)
+        data = data[idx]
+        radii = data[:, 0]
+
+    if data.shape[1] >= 7:
+        out = dict(radii=radii, u0=data[:, 4], ur=data[:, 5], uph=data[:, 6])
+    else:
+        out = dict(radii=radii, u0=data[:, 1], ur=data[:, 2], uph=data[:, 3])
+    if data.shape[1] >= 10:
+        out['hor'] = data[:, 9]            # scale height H/r
+    if data.shape[1] >= 11:
+        out['beta'] = data[:, 10]          # plasma beta
+    return out
+
+
+def u_from_fluid_file(a, r, cache, th=np.pi/2.):
+    """
+    Four-velocity linearly interpolated from a tabulated file.
+    By convention one file corresponds to a single spin.
+    Performs a one-time check of the normalization u_mu u^mu = -1,
+    which catches both unit errors and spin mismatches.
+    """
+    if not isinstance(r, np.ndarray):
+        r = np.array([r]).flatten()
+
+    radii = cache['radii']
+    rcl = np.clip(r, radii[0], radii[-1])  # clamp outside the tabulated range
+    u0 = np.interp(rcl, radii, cache['u0'])
+    u1 = np.interp(rcl, radii, cache['ur'])
+    u2 = np.zeros_like(u0)
+    u3 = np.interp(rcl, radii, cache['uph'])
+
+    # one-time normalization check on the tabulated grid itself,
+    # at theta(r) = arccos(H/r) if the scale height is tabulated
+    if not cache.get('_checked', False):
+        rr = radii
+        thg = th    # linear order in H/r: midplane metric (corrections are O((H/r)^2))
+        if cache.get('hor', None) is not None and cache.get('_surface_metric', False):
+            thg = np.arccos(np.clip(cache['hor'], 0., 1.))
+        a2 = a**2; r2 = rr**2
+        cth2 = np.cos(thg)**2; sth2 = np.sin(thg)**2
+        Delta = r2 - 2*rr + a2
+        Sigma = r2 + a2*cth2
+        g00 = -(1 - 2*rr/Sigma)
+        g11 = Sigma/Delta
+        g33 = (r2 + a2 + 2*rr*a2*sth2/Sigma)*sth2
+        g03 = -2*rr*a*sth2/Sigma
+        norm = (g00*cache['u0']**2 + 2*g03*cache['u0']*cache['uph']
+                + g11*cache['ur']**2 + g33*cache['uph']**2)
+        err = np.max(np.abs(norm + 1))
+        if err > 1e-3:
+            print(f"WARNING: tabulated u^mu normalization u.u = -1 violated "
+                  f"(max |u.u + 1| = {err:.2e}) for spin a={a}! "
+                  f"Check units (must be G=c=1, r in M) and the spin value.")
+        cache['_checked'] = True
+
+    return (u0, u1, u2, u3)

--- a/scripts/generate_semianalytic_image.py
+++ b/scripts/generate_semianalytic_image.py
@@ -20,19 +20,19 @@ from kgeo.velocities import Velocity
 from kgeo.emissivities import Emissivity
 
 # ============================ USER PARAMETERS ============================
-datafile = 'check_case.dat'      # <-- path to YOUR 9-column model file
+datafile = '../../check_case_shockfree.dat'      # <-- path to YOUR 9-column model file
 spin     = 0.94                  # BH spin; MUST match the model file
-th_o_deg = 30.                   # observer inclination in degrees (Sgr A*: low)
+th_o_deg = 0.1#163.0 #30.0                   # observer inclination in degrees (Sgr A*: low)
 nu_obs   = 230.e9                # observing frequency [Hz]
 
-MBH_msun = 4.2e6                 # Sgr A* mass in solar masses (your value)
-D_kpc    = 8.127                 # distance to Sgr A* [kpc] (GRAVITY 2018)
+MBH_msun = 6.5e9 #4.2e6                 # Sgr A* mass in solar masses (your value)
+D_kpc    = 16.8e3  #8.127                 # distance to Sgr A* [kpc] (GRAVITY 2018)
 
-npix     = 256                   # image pixels per side (512+ for production)
+npix     = 1024                   # image pixels per side (512+ for production)
 amax     = 15.                   # half field of view in units of M
 nmax     = 2                     # include photon subrings up to n=2
-Te_scale = 1.0                   # electron temperature = Te_scale * tabulated T
-outfile  = 'sgra_check_case'   # output name stem
+Te_scale = 3.4 #3.675(shock)                   # electron temperature = Te_scale * tabulated T
+outfile  = 'Midplane_M87_check_case_No_shock_Te=Ti_3'   # output name stem
 # =========================================================================
 
 # ---- physical scales set by the BH mass ----
@@ -99,8 +99,11 @@ U_cgs = U * rg_cm
 
 pix_sr   = (psize*thetag)**2                          # pixel solid angle [sr]
 Ftot_Jy  = I_cgs.sum() * pix_sr * 1.e23               # total flux density [Jy]
-print(f"total flux at {nu_obs/1e9:.0f} GHz: {Ftot_Jy:.4f} Jy")
-print(f"(Sgr A* observed ~2.4 Jy at 230 GHz -- use this to calibrate n_e normalization)")
+#print(f"total flux at {nu_obs/1e9:.0f} GHz: {Ftot_Jy:.4f} Jy")
+#print(f"(Sgr A* observed ~2.4 Jy at 230 GHz -- use this to calibrate n_e normalization)")
+
+print(f"total flux at {nu_obs/1e9:.0f} GHz: {Ftot_Jy:.6e} Jy")
+#ax[0].set_title(f'Stokes I, {nu_obs/1e9:.0f} GHz  ({Ftot_Jy:.3e} Jy)')
 
 # ---- plots ----
 ext_uas = amax*thetag_uas
@@ -108,7 +111,7 @@ extent  = [-ext_uas, ext_uas, -ext_uas, ext_uas]
 
 fig, ax = plt.subplots(1, 3, figsize=(15.5, 5))
 ax[0].imshow(I_cgs, origin='lower', extent=extent, cmap='afmhot')
-ax[0].set_title(f'Stokes I, {nu_obs/1e9:.0f} GHz  ({Ftot_Jy:.2f} Jy)')
+ax[0].set_title(f'Stokes I, {nu_obs/1e9:.0f} GHz  ({Ftot_Jy:.3e} Jy)')
 ax[0].set_xlabel(r'$\alpha$ [$\mu$as]'); ax[0].set_ylabel(r'$\beta$ [$\mu$as]')
 
 P = np.sqrt(Q_cgs**2 + U_cgs**2)
@@ -133,4 +136,4 @@ ax[2].set_xlabel(r'$\alpha$ [$\mu$as]')
 plt.tight_layout()
 plt.savefig(f'{outfile}.png', dpi=150, bbox_inches='tight')
 print(f"saved {outfile}.png")
-plt.show()
+#plt.show()

--- a/scripts/generate_semianalytic_image.py
+++ b/scripts/generate_semianalytic_image.py
@@ -1,0 +1,136 @@
+# Generate a black hole image from a tabulated semi-analytic model.
+#
+# Model file: ONE plain-text file (tab/space/comma separated, no header) with
+# 10 columns:
+#   r, b^0[G], b^r[G], b^phi[G], u^0, u^r, u^phi, n_e[cm^-3], T_e[K], H/r
+# (9-column files without H/r are also accepted; a constant opening angle is
+#  then used for the emitting column)
+# where r is the Boyer-Lindquist radius in units of M, b^mu is the fluid-frame
+# magnetic field four-vector (b^theta = 0), u^mu is the contravariant BL
+# four-velocity (u^theta = 0, normalized u_mu u^mu = -1, G=c=1).
+#
+# Requires the 'fluid_file' Bfield/Velocity types and the 'thermal_file'
+# Emissivity type added to kgeo-samik.
+
+import numpy as np
+import matplotlib.pyplot as plt
+from kgeo.equatorial_images import make_image
+from kgeo.bfields import Bfield
+from kgeo.velocities import Velocity
+from kgeo.emissivities import Emissivity
+
+# ============================ USER PARAMETERS ============================
+datafile = 'check_case.dat'      # <-- path to YOUR 9-column model file
+spin     = 0.94                  # BH spin; MUST match the model file
+th_o_deg = 30.                   # observer inclination in degrees (Sgr A*: low)
+nu_obs   = 230.e9                # observing frequency [Hz]
+
+MBH_msun = 4.2e6                 # Sgr A* mass in solar masses (your value)
+D_kpc    = 8.127                 # distance to Sgr A* [kpc] (GRAVITY 2018)
+
+npix     = 256                   # image pixels per side (512+ for production)
+amax     = 15.                   # half field of view in units of M
+nmax     = 2                     # include photon subrings up to n=2
+Te_scale = 1.0                   # electron temperature = Te_scale * tabulated T
+outfile  = 'sgra_check_case'   # output name stem
+# =========================================================================
+
+# ---- physical scales set by the BH mass ----
+G_cgs  = 6.67430e-8
+c_cgs  = 2.99792458e10
+Msun_g = 1.98892e33
+kpc_cm = 3.0857e21
+
+rg_cm    = G_cgs * MBH_msun * Msun_g / c_cgs**2        # gravitational radius [cm]
+D_cm     = D_kpc * kpc_cm
+thetag   = rg_cm / D_cm                                # angular size of 1 M [rad]
+thetag_uas = thetag * 180./np.pi * 3600. * 1.e6
+print(f"r_g = {rg_cm:.3e} cm   |  theta_g = {thetag_uas:.3f} micro-arcsec")
+print(f"field of view = {2*amax*thetag_uas:.1f} micro-arcsec")
+
+# ---- model objects: everything from your one file ----
+th_o     = th_o_deg * np.pi/180.
+if th_o_deg == 90.:
+    raise Exception("exactly edge-on (90 deg) is not supported; use e.g. 89.")
+
+# ---- data hygiene: drop tabulated points too close to the horizon, where
+# ---- u^0 diverges and finite-precision data cannot stay normalized ----
+rh = 1. + np.sqrt(1. - spin**2)
+_d = np.loadtxt(datafile)
+_keep = _d[:, 0] > rh + 5.e-3          # keep r > r_horizon + 0.005 M
+if (~_keep).sum() > 0:
+    print(f"data hygiene: dropping {(~_keep).sum()} point(s) within 0.005 M of the horizon")
+    datafile_clean = datafile + '.clean'
+    np.savetxt(datafile_clean, _d[_keep])
+else:
+    datafile_clean = datafile
+
+# linear order in H/r: vectors and metric at the midplane; the tabulated
+# scale height enters only the emitting column (pathlength), where it is linear
+if _d.shape[1] >= 10:
+    _rgrid, _hor = _d[_keep][:, 0], _d[_keep][:, 9]
+    diskangle = lambda r: np.interp(r, _rgrid, 2.*_hor, left=2.*_hor[0], right=2.*_hor[-1])
+    print(f"using tabulated H/r for the emitting column: 2H/r in [{2*_hor.min():.3f}, {2*_hor.max():.3f}]")
+else:
+    diskangle = 0.1   # kgeo default full opening angle
+
+velocity   = Velocity('fluid_file', file=datafile_clean)
+bfield     = Bfield('fluid_file', file=datafile_clean, velocity=velocity)
+emissivity = Emissivity('thermal_file', file=datafile_clean, Te_scale=Te_scale)   # n_e [cm^-3], T_e [K]
+
+# ---- raytrace and build the image ----
+psize = 2.*amax/npix
+out = make_image(spin, np.inf, th_o, nmax,
+                 -amax, amax, -amax, amax, psize,
+                 emissivity=emissivity, velocity=velocity, bfield=bfield,
+                 polarization=True, pathlength=True,
+                 specind=1, nu_obs=nu_obs, diskangle=diskangle)
+
+n = int(np.sqrt(out[0].shape[0]))
+I = np.nan_to_num(out[0]).sum(axis=1).reshape(n, n)   # erg s^-1 cm^-3 Hz^-1 sr^-1 * (path in M)
+Q = np.nan_to_num(out[1]).sum(axis=1).reshape(n, n)
+U = np.nan_to_num(out[2]).sum(axis=1).reshape(n, n)
+
+# ---- convert to physical units using the BH mass ----
+# pathlength from kgeo is in units of M -> multiply by rg_cm for cgs intensity
+I_cgs = I * rg_cm                                     # erg s^-1 cm^-2 Hz^-1 sr^-1
+Q_cgs = Q * rg_cm
+U_cgs = U * rg_cm
+
+pix_sr   = (psize*thetag)**2                          # pixel solid angle [sr]
+Ftot_Jy  = I_cgs.sum() * pix_sr * 1.e23               # total flux density [Jy]
+print(f"total flux at {nu_obs/1e9:.0f} GHz: {Ftot_Jy:.4f} Jy")
+print(f"(Sgr A* observed ~2.4 Jy at 230 GHz -- use this to calibrate n_e normalization)")
+
+# ---- plots ----
+ext_uas = amax*thetag_uas
+extent  = [-ext_uas, ext_uas, -ext_uas, ext_uas]
+
+fig, ax = plt.subplots(1, 3, figsize=(15.5, 5))
+ax[0].imshow(I_cgs, origin='lower', extent=extent, cmap='afmhot')
+ax[0].set_title(f'Stokes I, {nu_obs/1e9:.0f} GHz  ({Ftot_Jy:.2f} Jy)')
+ax[0].set_xlabel(r'$\alpha$ [$\mu$as]'); ax[0].set_ylabel(r'$\beta$ [$\mu$as]')
+
+P = np.sqrt(Q_cgs**2 + U_cgs**2)
+ax[1].imshow(P, origin='lower', extent=extent, cmap='viridis')
+ax[1].set_title('linear polarization $|P|$')
+ax[1].set_xlabel(r'$\alpha$ [$\mu$as]')
+
+# EVPA ticks over intensity
+ax[2].imshow(I_cgs, origin='lower', extent=extent, cmap='gray')
+chi = 0.5*np.arctan2(U_cgs, Q_cgs)
+xs  = np.linspace(-ext_uas, ext_uas, n); X, Y = np.meshgrid(xs, xs)
+s   = max(n//22, 1)
+m   = np.where(P > 0.05*P.max(), 1., np.nan)
+ax[2].quiver(X[::s,::s], Y[::s,::s],
+             (-np.sin(chi)*P/P.max()*m)[::s,::s],
+             ( np.cos(chi)*P/P.max()*m)[::s,::s],
+             color='cyan', scale=18, headwidth=1, headlength=0,
+             headaxislength=0, pivot='mid')
+ax[2].set_title('EVPA')
+ax[2].set_xlabel(r'$\alpha$ [$\mu$as]')
+
+plt.tight_layout()
+plt.savefig(f'{outfile}.png', dpi=150, bbox_inches='tight')
+print(f"saved {outfile}.png")
+plt.show()


### PR DESCRIPTION
This PR adds a script for generating polarized images from tabulated semi-analytic accretion-flow models.

The script reads a model table with columns:

r, b^t, b^r, b^phi, u^t, u^r, u^phi, n_e, T_e, H/r

and uses the existing kgeo imaging pipeline with:
- Velocity('fluid_file')
- Bfield('fluid_file')
- Emissivity('thermal_file')
- optional H/r-dependent path length

The script also converts the output intensity to physical flux density in Jy using the supplied black-hole mass and distance.

I would be grateful for feedback on the integration with the kgeo pipeline and the conventions used for the tabulated model quantities.